### PR TITLE
[semver:patch] feat: add show_skipped and SLACK_WEBHOOK_URL envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ As mentioned in our [FAQ](https://infracost.io/docs/faq), no cloud credentials o
 
 **Optional** If your repo has **multiple Terraform projects or workspaces**, define them in a [config file](https://www.infracost.io/docs/config_file/) and set this input to its path. Their results will be combined into the same diff output. Cannot be used with path, terraform_plan_flags or usage_file inputs. 
 
+### `show_skipped`
+
+**Optional** Show unsupported resources, some of which might be free, at the bottom of the Infracost output (default is false).
+
 ### `post_condition`
 
 **Optional** A JSON string describing the condition that triggers pull request comments, can be one of these:
@@ -110,6 +114,10 @@ For all other users, the following is needed so Terraform can run `init`:
 ### `GIT_SSH_KEY`
 
 **Optional** If you're using Terraform modules from private Git repositories you can set this environment variable to your private Git SSH key so Terraform can access your module.
+
+### `SLACK_WEBHOOK_URL`
+
+**Optional** Set this to also post the pull request comment to a [Slack Webhook](https://slack.com/intl/en-tr/help/articles/115005265063-Incoming-webhooks-for-Slack), which should post it in the corresponding Slack channel.
 
 ## Contributing
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -36,6 +36,10 @@ jobs:
           - `'{"percentage_threshold": 0}'`: absolute percentage threshold that triggers a comment. For example, set to 1 to post a comment if the cost estimate changes by more than plus or minus 1%.
         default: '{"has_diff": true}'
         type: string
+      show_skipped:
+        description: Show unsupported resources, some of which might be free, at the bottom of the Infracost output.
+        default: "false"
+        type: string
     environment:
       path: << parameters.path >>
       terraform_plan_flags: << parameters.terraform_plan_flags >>
@@ -43,6 +47,7 @@ jobs:
       usage_file: << parameters.usage_file >>
       config_file: << parameters.config_file >>
       post_condition: << parameters.post_condition >>
+      show_skipped: << parameters.show_skipped >>
     steps:
       - checkout
       - run: /scripts/ci/diff.sh
@@ -53,7 +58,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        infracost: infracost/infracost@0.7.0
+        infracost: infracost/infracost@0.8.1
       workflows:
         main:
           jobs:


### PR DESCRIPTION
- show_skipped works as it does in the CLI
- setting the Slack webhook posts the comment to Slack too

to be released as part of Infracost v0.9.3